### PR TITLE
add no-deps option to meta.yaml template

### DIFF
--- a/doc/development/guidelines.md
+++ b/doc/development/guidelines.md
@@ -387,7 +387,7 @@ source:
 build:
   noarch: python
   preserve_egg_dir: True
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   build:


### PR DESCRIPTION
Add no-deps option to ensure clean conda build (avoid unwanted pip install during build)