### PR TITLE
added things about run CI locally

### DIFF
--- a/doc/development/how-to-release.md
+++ b/doc/development/how-to-release.md
@@ -42,6 +42,15 @@ The requests for the release are:\
 We choose to rely on CI/CD to build `OpenAlea` packages. This allows us to automate the build process, ensuring that all packages are built consistently and reliably. The CI/CD pipeline is extensively documented in the [dedicated Development Guidelines](guidelines.md#ci-cd) and in the [dedicated OpenAlea github action documentation](https://github.com/openalea/action-build-publish-anaconda/blob/main/doc/workflows/openalea_ci/README.md).
 
 However, during the development phase, you may want to build and test your package locally, without the hassle to commit and push changes (sometimes multiple times) to test the building process. To do so, we recommand to use the [VS-Code GitHub Local Actions extension](https://marketplace.visualstudio.com/items?itemName=SanjulaGanepola.github-local-actions), that allows you to run the GitHub Actions locally inside your IDE, without messing up your local environment (as it can be the case using directly `conda-build`).
+If you are note using VS-Code, you can directly use [act](https://github.com/nektos/act) to run locally the GitHub 
+Action locally. First install `act` under your environment:
+```commandline
+mamba install act -c conda-forge
+```
+Then under the root folder of your project, run the following:
+```commandline
+act pull_request -s ANACONDA_TOKEN=""
+```
 
 ```{note}
 One (minor) drawback with this solution is that the version number of your package may not be updated automatically, and thus probably not in sync with the version created in the CI/CD pipeline that would be uploaded to your conda channel.

--- a/doc/development/using_cookiecutter.md
+++ b/doc/development/using_cookiecutter.md
@@ -166,7 +166,15 @@ def test_functions():
 ```
 
 ### Building and testing locally the package
-Now let's locally build the package. First install the necessary packages:
+Now let's locally build the package. 
+
+There are two possibilities. We recommend to use a VS-Code plugin or directly [act](https://github.com/nektos/act) to 
+run the OpenAlea GitHub Action locally. Or, you can use `conda-build` to build and run tests locally. However, that can 
+messing up your local environment and that does not run the remote Openalea CI.
+
+You can find details of the first recommended solution in [Building the package](https://openalea.readthedocs.io/en/latest/development/how-to-release.html).
+
+For the second solution, first install the necessary packages:
 ```commandline
 mamba install conda-build pytest
 ```


### PR DESCRIPTION
in `how to release` and `using cookiecutter`